### PR TITLE
Changed from 'metadata__' to 'meta' which is in componenet

### DIFF
--- a/.github/workflows/new_bug_fix.yml
+++ b/.github/workflows/new_bug_fix.yml
@@ -1,0 +1,81 @@
+name: Create a new version and push to PyPi and GitHub
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  create_version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+
+      - uses: actions/checkout@v4
+        with:
+          repository: revisit-studies/study
+          path: study
+
+      - name: Copy new study docs to docs and cleanup
+        run: |
+          cp study/src/parser/StudyConfigSchema.json src/revisitpy/
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+
+      - name: Run CodeGen
+        run: |
+          uv venv
+          uv pip install datamodel-code-generator
+          uv run datamodel-codegen --input src/revisitpy/StudyConfigSchema.json --output src/revisitpy/models.py  --custom-template-dir custom_templates --output-model-type pydantic_v2.BaseModel --additional-imports "typing.TypedDict, warnings" --input-file-type jsonschema --special-field-name-prefix we_are_going_to_replace_this && sed -i -E 's/we_are_going_to_replace_this_//g' src/revisitpy/models.py
+
+      - name: Update pyproject.toml version
+        run: |
+          # Extract the current version
+          MAJOR_VERSION=$(sed -nE 's/^version = "([0-9]+)\.[0-9]+\.[0-9]+"/\1/p' pyproject.toml)
+          MINOR_VERSION=$(sed -nE 's/^version = "[0-9]+\.([0-9]+)\.[0-9]+"/\1/p' pyproject.toml)
+          BUG_FIX_VERSION=$(sed -nE 's/^version = "[0-9]+\.[0-9]+\.([0-9]+)"/\1/p' pyproject.toml)
+
+
+          # Increment the bug fix version
+          NEW_BUG_FIX_VERSION=$((BUG_FIX_VERSION + 1))
+          NEW_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${NEW_BUG_FIX_VERSION}"
+
+          # Update the version in pyproject.toml
+          sed -i -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "'"${NEW_VERSION}"'"/' pyproject.toml
+
+          # Print the new version for debugging
+          echo "New version: ${NEW_VERSION}"
+
+      - name: Hatch Install
+        run: |
+          uv pip install hatch
+
+      - name: Hatch Build
+        run: |
+          uv run hatch build
+
+      # - name: Hatch Build
+      #   run: |
+      #     uv hatch publish
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.email "jackwilburn@tutanota.com"
+          git config --global user.name "Jack Wilburn"
+          git pull
+          git add src
+          git commit -m "Create a new version based on the latest tag"
+          git push

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ The individual classes (`Component`, `Response`, `Sequence`, `StudyMetadata`, `U
 
 # Functions
 
-# Functions
-
 ### `component(component_name__, base__, **kwargs) -> Component`
 
 Instantiates a Component class with the given input parameters.
@@ -43,7 +41,7 @@ Instantiates a Component class with the given input parameters.
 
 ### **Example**:
 ```python
-import revisitpy as rvt
+import revisit as rvt
 
 # Initializing a markdown component with an empty response list.
 my_component = rvt.component(
@@ -80,7 +78,7 @@ Instantiates a Response class with the given input parameters.
 
 ### **Example**:
 ```python
-import revisitpy as rvt
+import revisit as rvt
 
 # Initializing a matrix radio response
 my_response = rvt.response(
@@ -109,7 +107,7 @@ Instantiates a StudyMetadata class with the given parameters.
 
 ### **Example**:
 ```python
-import revisitpy as rvt
+import revisit as rvt
 
 # Initializing a matrix radio response
 my_response = rvt.response(
@@ -138,7 +136,7 @@ Instantiates a UIConfig class with the given parameters.
 
 ### **Example**:
 ```python
-import revisitpy as rvt
+import revisit as rvt
 
 # Initializing a matrix radio response
 my_response = rvt.response(
@@ -186,6 +184,53 @@ study = rvt.studyConfig(
 )
 ```
 
+
+### `data(file_path)`
+
+Parses a CSV file with the given `file_path` and returns a list of DataRows. Output can be passed into the `from_data` method of the `sequence` class to generate components based on the CSV data.
+
+### **Parameters**:
+| Parameter | Type   | Description                     | Default Value |
+|-----------|--------|---------------------------------|---------------|
+| `file_path` | `str` | Path to the CSV file | _None_ |
+
+### **Returns**:
+- `List[DataRow]`: Returns a list of dataclasses called `DataRow`. 
+
+
+### **Example**:
+
+In the below example, we create the study data using the `data` method, then create a sequence from this data using the `from_data` method. Each component shown in the new sequence will have the respective data added to their `meta` attribute. From here, you can use the `component` method of the `Sequence` class to transform each component based on their respective `meta` attributes that you applied with `from_data` method.
+
+```python
+
+'''
+'my_csv_file.csv' contents
+
+id | value_1 | value_2
+---|---------|--------
+ 1 | 0.3     | 3
+ 2 | 0.1     | 4
+ 3 | 1.2     | 1
+'''
+
+study_data = rvt.data('path/to/my_csv_file.csv')
+
+sequence = rvt.sequence(order='fixed').from_data(study_data)
+
+print(sequence)
+'''
+{
+    "order": "fixed",
+    "components": [
+        'id:1__value_1:0.3__value_2:3',
+        'id:2__value_1:0.1__value_2:4',
+        'id:3__value_1:1.2__value_2:1',
+    ]
+}
+'''
+```
+
 # Classes 
 
 ## `Component`
@@ -197,13 +242,12 @@ The class that is instantiated when calling the `component` factory function. Us
 |-------------|----------|-------------------------------------|---------------|
 | `component_name__`     | `str`   | Name of the component to be used as the key in the study config.        | _None_     |
 | `base__`     | `Optional[Component]`   | The base component which is inherited by this component.         | _None_        |
-| `metadata__` | `Optional[dict]` | A dictionary specifying metadata of the object. This is purely used for additional properties which are not written to the config and may be used to attach arbitrary data to the component without affecting the final output. | _None_ |
+| `meta` | `Optional[dict]` | A dictionary specifying metadata of the object. These attributes _are_ a part of the underlying component and will be shown when printing the components or the final configuration. These are used to attach arbitrary attributes to the component as well as for use with the `Sequence` class's `component` function. This attribute can also be set through the `Sequence` class's `permute` and `from_data` methods. | _None_ |
 
 ### **Methods**:
 
 #### `responses(responses: List[Response]) -> self`
 
-**Description**:  
 Sets responses for the component
 
 **Parameters**:  
@@ -215,7 +259,7 @@ Sets responses for the component
 - `self`: Returns self for method chaining.
 
 **Raises**:  
-- `RevisitError`: If the list is not a valid list of responses, raises and exception.
+- `RevisitError`: If the list is not a valid list of responses, raises an exception.
 
 **Example**:
 ```python
@@ -236,7 +280,7 @@ my_component = rvt.component(
 
 #### `get_response(id: str) -> Response | None`
 
-**Description**:
+
 Returns the response of the component with the given ID. If the Response does not exist, returns `None`.
 
 **Parameters**:  
@@ -257,7 +301,6 @@ if the_response is not None:
 
 #### `edit_response(id: str, **kwargs: dict) -> self`
 
-**Description**:
 Edits the Response in the Component with the given ID. This is done by creating a new copy of the existing Response.
 
 **Parameters**:  
@@ -320,9 +363,19 @@ print(component_two)
 '''
 ```
 
+#### `get(param) -> Any`
+
+Retrieves the given parameter from the component. The param `'name'` can be used as shorthand for `'component_name__'`.
+
+**Parameters**:  
+| Parameter   | Type     | Description                         | Default Value |
+|-------------|----------|-------------------------------------|---------------|
+| `param`    | `str`   | Parameter name to be retrieved      | _None_     |
+
+
 #### `clone(component_name__) -> Component`
 
-**Description**:
+
 Clones the component with the given new component name.
 
 **Parameters**:  
@@ -392,9 +445,19 @@ _No attributes_
 
 ### **Methods**:
 
+#### `get(param) -> Any`
+
+Retrieves the given parameter from the response. The param `'name'` can be used as an alternative for `'id'`.
+
+**Parameters**:  
+| Parameter   | Type     | Description                         | Default Value |
+|-------------|----------|-------------------------------------|---------------|
+| `param`    | `str`   | Parameter name to be retrieved      | _None_     |
+
+
 #### `set(**kwargs: dict) -> self`
 
-**Description**:
+
 
 Sets the values of the response to the input dictionary. The `type` cannot be changed and would require creating a new response
 
@@ -441,7 +504,7 @@ response_one.set(options=[1,2,3])
 
 #### `clone() -> Response`
 
-**Description**:
+
 Clones the response.
 
 **Parameters**:  
@@ -516,7 +579,7 @@ Expected Output:
 
 ## `ComponentBlock`
 
-**Description**:  
+  
 The `ComponentBlock` class (also referred to as a "Sequence"). A well-defined sequence simply contains an order and a set of components, with other optional properties. Just as in the nested structure of component blocks in the reVISit study configuration, `ComponentBlock` classes can be added together.
 
 A `ComponentBlock` automatically tracks all of its existing `Component` classes. When the `ComponentBlock` is added to the study configuration, all components will automatically be added to the high-level components element of the study config.
@@ -529,7 +592,7 @@ _No attributes_
 
 #### `__add__(other: Union[ComponentBlock, Component]) -> self:`
 
-**Description**:
+
 
 Adds two `ComponentBlock` or `Component` to the input sequence. When adding two sequences together, the right sequence gets added as a `ComponentBlock` to the list of components of the left sequence. When the right object is an instance of the `Component` class, the component is added to the `ComponentBlock`'s list of components.
 
@@ -604,7 +667,7 @@ Expected Output:
 
 #### `get_component(name: str) -> Component:`
 
-**Description**:
+
 
 Fetches the `Component` with the given component name from the sequence.
 
@@ -636,10 +699,141 @@ print(sequence.get_component(name='comp_two'))
 '''
 ```
 
-#### `permute(factors: List[dict], order: 'fixed' | 'latinSquare' | 'random', numSamples: Optional[int], component_function: Optional[Callable]) -> self`
+#### `get_components() -> List[Component]`
 
-**Description**:
-Permutes the the existing components of the sequence over the given `factors`. The permute method can be chained to complex study sequences. By default, the factors are attached as `metadata__` attributes to each component created. If a `component_function` is passed in as an argument, all current factors and `metadata__` of the component will be passed into the component function. The component function must return a valid `Component` instance. 
+Fetches the list of all components in the sequence.
+
+**Parameters**:  
+_None_
+
+**Returns**:
+- `List[Component]`: Returns list of all components in the sequence.
+
+
+**Examples**:
+```python
+
+sequence = rvt.sequence(
+    order='random',
+    components=[comp_one, comp_two]
+)
+
+# Fetches first component in component list.
+print(sequence.get_components()[0])
+'''
+{
+    "type": "markdown",
+    "path": "my_markdown_file.md",
+    "response": []
+}
+'''
+```
+
+
+#### `component(component_function: Optional[Callable]) -> self`
+
+Maps each component in the current sequence to the result of the inputted `component_function`. This will maintain the entire structure of the sequence and will recursively call this function to replace every component.
+
+The `met` attribute of the components are passed in as arguments to the `component_function`. This makes it especially useful after using the `permute` or `from_data` methods since both add `meta` attributes to the components. If an exception is raised when calling the `component_function`, the original input component will be used in its stead.  Additionally, the `component_function` can also take in the `component__` parameter which is the original component that is being transformed. 
+
+#### **Examples**:
+
+**Simple component function to change the name**
+```python
+
+# Basic component function
+def my_component_function(id, value):
+    return rvt.component(
+        component_name__=f"{id}_{value}"
+        type='website',
+        path='path/to/html',
+    )
+
+
+first_boring_component = rvt.component(type='questionnaire',meta={'id': 1, 'value': 2}, component_name__='bor-comp-1')
+second_boring_component = rvt.component(type='questionnaire',meta={'id': 2, 'value': 7}, component_name__='bor-comp-2')
+
+sequence = rvt.sequence(order='fixed', components=[first_boring_component, second_boring_component])
+
+print(sequence)
+'''
+{
+    'order':'fixed',
+    'components':[
+        'bor-comp-1',
+        'bor-comp-2'
+    ]
+}
+'''
+
+sequence.component(my_component_function)
+
+print(sequence)
+'''
+{
+    'order':'fixed',
+    'components':[
+        '1_2',
+        '2_7'
+    ]
+}
+'''
+```
+
+**Passing in Original Components**
+
+In the example below, we'll use the original component to determine if we want to append the `meta` as parameters.
+
+```python
+def my_component_function(id, value, component__):
+    if component__.get('type') === 'website':
+        return rvt.component(
+            component_name__=f"website_{id}_{value}"
+            type='website',
+            path='path/to/html',
+            parameters={
+                'id':id,
+                'value':value
+            }
+        )
+    
+    return rvt.component(
+        component_name__=f'questionnaire_{id}_{value}'
+        type='questionnaire',
+    )
+
+first_boring_component = rvt.component(type='questionnaire',meta={'id': 1, 'value': 2}, component_name__='bor-comp-1')
+second_boring_component = rvt.component(type='website',meta={'id': 2, 'value': 7}, component_name__='bor-comp-2')
+
+sequence = rvt.sequence(
+    order='fixed',
+    components=[first_boring_component, second_boring_component]
+).component(my_component_function)
+
+print(sequence)
+
+'''
+{
+    'order':'fixed',
+    'components':[
+        'questionnaire_1_2',
+        'website_2_7'
+    ]
+}
+'''
+```
+
+:::info
+If you'd like to have your `component_function` always take in all `meta` entries and the original component, you can define your component function using the `kwargs` keyword like `def my_component_function(**kwargs)`. Then, to access each entry, you can use `kwargs.get('my_metadata_key')` and `kwargs.get('component__')`.
+:::
+
+You can find more examples of using the `component` method in the [Scatter JND Example](../../revisitpy/examples/example_jnd_study) where we first construct a sequence by permuting over multiple factors, then using the `component` method to alter the components based on the `meta` that is applied during th permutation method.
+
+
+#### `permute(factors: List[dict], order: 'fixed' | 'latinSquare' | 'random', numSamples: Optional[int]) -> self`
+
+
+Permutes the the existing components of the sequence over the given `factors`. The permute method can be chained to complex study sequences. By default, the factors are attached as `meta` attributes to each component created.
 
 **Parameters**:  
 | Parameter   | Type     | Description                         | Default Value |
@@ -647,13 +841,9 @@ Permutes the the existing components of the sequence over the given `factors`. T
 | `factors`   | `List[dict]`   | A list of single-key dictionaries to permute over. | _None_     |
 | `order` | `'fixed' \| 'latinSquare' \| 'random' ` |The order to assign to the current permuted component block. |  _None_ |
 | `numSamples` | `Optional[int]` | The `numSamples` value to assign to the current permuted block. | _None_ |
-| `component_function` | `Optional[Callable]` | A function defining what component should be generated during permutation. If not provided, the permutation function inherits the existing components in the sequence as new components and applies the factors as metadata. If given, the metadata is passed into the component function as arguments.  | _None_ |
 
 **Returns**:
 - `self`: Returns self for method chaining.
-
-**Raises**:
-- `TypeError`: The `component_function` must be able to take in all metadata of the sequence's existing components as well as the current factors. For example, if you start with a component with no metadata and permute over the factors `[{'key_1':'value_1'}, {'key_1': 'value_2'}]`, the component function should be defined to take in the parameter `key_1`. Otherwise, this will most likely result in a `TypeError` being raised. If you are chaining multiple permute methods after one another, please note that the the set of factors that are passed into the permute function are applied as metadata to the resulting components. Thus, your function must be able to take in all factors as arguments. To avoid this, you can simply use `**kwargs` as your parameter input of your component function.
 
 #### **Examples**:
 
@@ -680,8 +870,8 @@ Expected Output:
     ]
 }
 
-The two components generated are inherently identical, except with different metadata__ attributes. 
-These metadata__ attributes are not outputed into the final JSON study config or seen when printing out
+The two components generated are inherently identical, except with different meta attributes. 
+These meta attributes are not outputed into the final JSON study config or seen when printing out
 the individual components.
 '''
 
@@ -719,7 +909,7 @@ Expected Output:
 '''
 ```
 
-**Using the `component_function`**
+**Using the `component_function` in the `component` method**
 
 ```python
 # Defining component function.
@@ -757,8 +947,8 @@ sequence = rvt.sequence(order='fixed').permute(
     factors=[{'type':'1'}, {'type': '2'}]
     order='fixed',
     numSamples=1,
-    component_function=my_comp_function
-)
+).component(component_function) # <-- Uses component method to map each component to the result of the component_function
+
 print(sequence)
 '''
 Expected Output:
@@ -786,9 +976,49 @@ Expected Output:
 }
 '''
 ```
-## Development
 
-### Building
+
+
+#### `from_data(data_list) -> self`
+
+The `from_data` method iterates over a list of `DataRows` and appends the data to the `meta` attribute of the components in the sequence. You can generate a list of `DataRows` by using the [data function](./functions.md#datafile_path) to parse a CSV file.
+
+### **Example**:
+
+In the below example, we create the study data using the `data` method, then create a sequence from this data using the `from_data` method. Each component shown in the new sequence will have the respective data added to their `meta` attribute. From here, you can use the `component` method of the `Sequence` class to transform each component based on their respective `meta` attributes that you applied with the `from_data` method.
+
+```python
+
+'''
+'my_csv_file.csv' contents
+
+id | value_1 | value_2
+---|---------|--------
+ 1 | 0.3     | 3
+ 2 | 0.1     | 4
+ 3 | 1.2     | 1
+'''
+
+study_data = rvt.data('path/to/my_csv_file.csv')
+
+sequence = rvt.sequence(order='fixed').from_data(study_data)
+
+print(sequence)
+'''
+{
+    "order": "fixed",
+    "components": [
+        'id:1__value_1:0.3__value_2:3',
+        'id:2__value_1:0.1__value_2:4',
+        'id:3__value_1:1.2__value_2:1',
+    ]
+}
+'''
+```
+
+# Development
+
+## Building
 
 You may need to install hatch locally (do not use `uv add hatch` since it will add it to project dependencies and be shipped with build).
 
@@ -833,14 +1063,14 @@ to start developing. Changes made in `js/` will be reflected
 in the notebook.
 
 
-## CODE GEN
+## Code Generation
 
 ```bash
 uv pip install datamodel-code-generator
 uv run datamodel-codegen --input src/revisitpy/StudyConfigSchema.json --output src/revisitpy/models.py  --custom-template-dir custom_templates --output-model-type pydantic_v2.BaseModel --additional-imports "typing.TypedDict, warnings" --input-file-type jsonschema --special-field-name-prefix we_are_going_to_replace_this && sed -i '' 's/we_are_going_to_replace_this_//g'  src/revisitpy/models.py
 ```
 
-## TESTS
+## Tests
 
 ```bash
 cd revisit-py

--- a/scripts/test_script.py
+++ b/scripts/test_script.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     study_data = rvt.data('./scripts/data.csv')
 
     def component_function(id, r1, r2, position, component__):
-        if component__.type == 'questionnaire':
+        if component__.get('type') == 'questionnaire':
             print('hello')
         return rvt.component(
             type='website',
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     comp_one = rvt.component(
         component_name__='my-component',
         type='questionnaire',
-        metadata__={
+        meta={
             "id": random.randint(1, 10),
             'r1': random.randint(1, 10),
             'r2': random.randint(1, 10),
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     comp_two = rvt.component(
         component_name__='my-component',
         type='questionnaire',
-        metadata__={
+        meta={
             'id': 3
         }
     )
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         order='random'
     )
 
-    # print(sequence_three)
+    print(sequence_three)
     '''
     Output:
 
@@ -200,20 +200,3 @@ if __name__ == "__main__":
         "order": "fixed"
     }
     '''
-
-    print(comp_one.get('type'))
-
-    print(sequence_three.get_components()[0])
-    # print(sequence_three.get_component("my-component__r1:1__r2:4__position:True"))
-    # response_one = rvt.response(
-    #     id='r-1',
-    #     type='shortText',
-    #     required=False,
-    #     location='belowStimulus',
-    #     prompt=''
-    # )
-
-    # response_one.set(prompt='New Prompt')
-    # print(response_one)
-
-    # response_one.set(options=['Option 1', 'Option 2', 'Option 3'])


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #30 #32 

### Give a longer description of what this PR addresses and why it's needed
- Updated to use "meta" rather than "metadata__" for attaching data to components since this is already built into reVISit spec.
- Added github workflow for bug fix version

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update revisitpy-examples with change in metadata